### PR TITLE
Require at least one non-whitespace character in directives.

### DIFF
--- a/mountain/join.py
+++ b/mountain/join.py
@@ -20,7 +20,7 @@ def expand_manifest(manifest_path, combined_document_path):
     # All referenced files in the manifest are relative to this base path.
     base_path = os.path.dirname(manifest_path)
 
-    referenced_file_names = (re.compile("\[\[\s*#include\s+(.*)\s*\]\]")
+    referenced_file_names = (re.compile("\[\[\s*#include\s+(\S.*?)\s*\]\]")
                                .findall(manifest))
 
     for file_name in referenced_file_names:

--- a/mountain/split.py
+++ b/mountain/split.py
@@ -20,7 +20,7 @@ def split_combined_document(manifest_path, combined_document_path):
     base_path = os.path.dirname(manifest_path)
 
     references = re.findall(
-        "\[\[#reference\s+(.*?)\]\](.*?)\[\[/reference\]\]",
+        "\[\[#reference\s+(\S.*?)\]\](.*?)\[\[/reference\]\]",
         combined_document,
         re.DOTALL)
 


### PR DESCRIPTION
This fixes a crash caused by using `[[#include   ]]` (note the whitespace after the `#include`). This  fix ignores any directives that do not include a non-whitespace character.
